### PR TITLE
Prevent partial create-account registrations for app-community#65

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -1,0 +1,28 @@
+name: Pull Request Checks
+
+on:
+  pull_request:
+  push:
+    branches:
+      - task-65
+
+jobs:
+  people-module:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+
+      - name: Validate composer files
+        run: composer validate --no-check-publish
+
+      - name: Install test dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,19 @@
             "ControleOnline\\Controller\\": "src/Controller/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "ControleOnline\\Tests\\": "tests/"
+        }
+    },
     "authors": [
         {
             "name": "Controle Online",
             "email": "luiz.kim@controleonline.com"
         }
     ],
-    "require": {}
+    "require": {},
+    "require-dev": {
+        "phpunit/phpunit": "^12.1"
+    }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.1/phpunit.xsd"
+    bootstrap="tests/bootstrap.php"
+    colors="true"
+    cacheDirectory=".phpunit.cache"
+>
+    <testsuites>
+        <testsuite name="People Module Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Controller/CreateAccountAction.php
+++ b/src/Controller/CreateAccountAction.php
@@ -7,6 +7,7 @@ use ControleOnline\Service\AccountRegistrationService;
 use ControleOnline\Service\HydratorService;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 
 class CreateAccountAction
 {
@@ -33,7 +34,7 @@ class CreateAccountAction
 
       return new JsonResponse(
         $this->hydratorService->error($e),
-        500
+        $e instanceof HttpExceptionInterface ? $e->getStatusCode() : 500
       );
     }
   }

--- a/src/Service/AccountRegistrationService.php
+++ b/src/Service/AccountRegistrationService.php
@@ -2,6 +2,9 @@
 
 namespace ControleOnline\Service;
 
+use ControleOnline\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
 use ControleOnline\Entity\People;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
@@ -10,7 +13,8 @@ class AccountRegistrationService
     public function __construct(
         private UserService $userService,
         private PeopleService $peopleService,
-        private DomainService $domainService
+        private DomainService $domainService,
+        private EntityManagerInterface $manager
     ) {}
 
     public function registerFromContent(?string $content): People
@@ -25,62 +29,126 @@ class AccountRegistrationService
             throw new BadRequestHttpException('people is required');
         }
 
-        foreach (['name', 'alias', 'email', 'phone'] as $field) {
+        foreach (['name', 'email', 'phone'] as $field) {
             if (!isset($peopleData[$field])) {
-                throw new BadRequestHttpException('name, alias, email and phone are required');
+                throw new BadRequestHttpException('people.name, people.email and people.phone are required');
             }
         }
 
         $phoneData = is_array($peopleData['phone'] ?? null) ? $peopleData['phone'] : [];
         foreach (['ddi', 'ddd', 'phone'] as $field) {
             if (!isset($phoneData[$field])) {
-                throw new BadRequestHttpException('phone.ddi, phone.ddd and phone.number are required');
+                throw new BadRequestHttpException('people.phone.ddi, people.phone.ddd and people.phone.phone are required');
             }
         }
 
-        $people = $this->peopleService->discoveryPeople(
-            $peopleData['document'] ?? null,
-            $peopleData['email'],
-            $phoneData,
-            trim($peopleData['name'] . ' ' . $peopleData['alias']),
-            'F'
+        $personName = trim(sprintf(
+            '%s %s',
+            (string) ($peopleData['name'] ?? ''),
+            (string) ($peopleData['alias'] ?? '')
+        ));
+        $personEmail = trim((string) ($peopleData['email'] ?? ''));
+        $personDocument = $this->normalizeDocument($peopleData['document'] ?? null);
+        $personPhone = $this->normalizePhoneData($phoneData);
+
+        if ($personName === '') {
+            throw new BadRequestHttpException('people.name is required');
+        }
+
+        if ($personEmail === '') {
+            throw new BadRequestHttpException('people.email is required');
+        }
+
+        if ($personPhone['ddd'] === '' || $personPhone['phone'] === '') {
+            throw new BadRequestHttpException('people.phone.ddd and people.phone.phone are required');
+        }
+
+        $this->assertPersonIdentifiersAreAvailable(
+            $personDocument,
+            $personEmail,
+            $personPhone
         );
 
-        $client = $people;
-
-        if (is_array($payload['company'] ?? null)) {
-            $companyData = $payload['company'];
-            $company = $this->peopleService->discoveryPeople(
-                $companyData['document'] ?? null,
-                $companyData['email'] ?? null,
-                is_array($companyData['phone'] ?? null) ? $companyData['phone'] : null,
-                $companyData['name'] ?? null,
-                'J'
+        $companyData = is_array($payload['company'] ?? null) ? $payload['company'] : null;
+        if ($companyData) {
+            $companyDocument = $this->normalizeDocument($companyData['document'] ?? null);
+            $companyEmail = trim((string) ($companyData['email'] ?? ''));
+            $companyPhone = $this->normalizePhoneData(
+                is_array($companyData['phone'] ?? null) ? $companyData['phone'] : null
             );
 
-            $this->peopleService->discoveryLink($company, $people, 'employee');
-            $client = $company;
+            $this->assertCompanyIdentifiersAreAvailable(
+                $companyDocument,
+                $companyEmail,
+                $companyPhone
+            );
         }
-
-        $mainCompany = $this->domainService->getPeopleDomain()->getPeople();
-        $this->peopleService->discoveryLink($mainCompany, $client, 'client');
 
         if (is_array($peopleData['user'] ?? null)) {
-            if (
-                !isset($peopleData['user']['user']) ||
-                !isset($peopleData['user']['password'])
-            ) {
-                throw new BadRequestHttpException('user.user and user.password are required');
+            $username = trim((string) ($peopleData['user']['user'] ?? ''));
+            $password = (string) ($peopleData['user']['password'] ?? '');
+
+            if ($username === '') {
+                throw new BadRequestHttpException('people.user.user is required');
             }
 
-            $this->userService->createUser(
-                $people,
-                $peopleData['user']['user'],
-                $peopleData['user']['password']
-            );
+            if ($password === '') {
+                throw new BadRequestHttpException('people.user.password is required');
+            }
+
+            $this->assertUsernameIsAvailable($username);
         }
 
-        return $client;
+        $connection = $this->manager->getConnection();
+        $connection->beginTransaction();
+
+        try {
+            $people = $this->peopleService->discoveryPeople(
+                $personDocument,
+                $personEmail,
+                $personPhone,
+                $personName,
+                'F'
+            );
+
+            $client = $people;
+
+            if ($companyData) {
+                $company = $this->peopleService->discoveryPeople(
+                    $this->normalizeDocument($companyData['document'] ?? null),
+                    trim((string) ($companyData['email'] ?? '')) ?: null,
+                    is_array($companyData['phone'] ?? null)
+                        ? $this->normalizePhoneData($companyData['phone'])
+                        : null,
+                    trim((string) ($companyData['name'] ?? '')),
+                    'J'
+                );
+
+                $this->peopleService->discoveryLink($company, $people, 'employee');
+                $client = $company;
+            }
+
+            $mainCompany = $this->domainService->getPeopleDomain()->getPeople();
+            $this->peopleService->discoveryLink($mainCompany, $client, 'client');
+
+            if (is_array($peopleData['user'] ?? null)) {
+                $this->userService->createUser(
+                    $people,
+                    trim((string) $peopleData['user']['user']),
+                    (string) $peopleData['user']['password']
+                );
+            }
+
+            $connection->commit();
+
+            return $client;
+        } catch (\Throwable $exception) {
+            if ($connection->isTransactionActive()) {
+                $connection->rollBack();
+            }
+
+            throw $exception;
+        }
     }
 
     private function decodePayload(?string $content): array
@@ -92,5 +160,86 @@ class AccountRegistrationService
         $decoded = json_decode($content, true);
 
         return is_array($decoded) ? $decoded : [];
+    }
+
+    private function normalizeDocument(mixed $document): ?string
+    {
+        $normalized = preg_replace('/\D/', '', (string) ($document ?? ''));
+
+        return $normalized !== '' ? $normalized : null;
+    }
+
+    private function normalizePhoneData(?array $phoneData): array
+    {
+        $rawPhoneData = is_array($phoneData) ? $phoneData : [];
+
+        return [
+            'ddi' => preg_replace('/\D/', '', (string) ($rawPhoneData['ddi'] ?? '55')) ?: '55',
+            'ddd' => preg_replace('/\D/', '', (string) ($rawPhoneData['ddd'] ?? '')),
+            'phone' => preg_replace('/\D/', '', (string) ($rawPhoneData['phone'] ?? '')),
+        ];
+    }
+
+    private function assertPersonIdentifiersAreAvailable(
+        ?string $document,
+        string $email,
+        array $phoneData
+    ): void {
+        if ($document && $this->peopleService->getDocument($document)) {
+            throw new ConflictHttpException('Este CPF já está cadastrado.');
+        }
+
+        if ($this->peopleService->getEmail($email)) {
+            throw new ConflictHttpException('Este e-mail já está cadastrado.');
+        }
+
+        if (
+            $phoneData['ddd'] !== '' &&
+            $phoneData['phone'] !== '' &&
+            $this->peopleService->getPhone(
+                (int) $phoneData['ddi'],
+                (int) $phoneData['ddd'],
+                $phoneData['phone']
+            )
+        ) {
+            throw new ConflictHttpException('Este telefone já está cadastrado.');
+        }
+    }
+
+    private function assertCompanyIdentifiersAreAvailable(
+        ?string $document,
+        string $email,
+        array $phoneData
+    ): void {
+        if ($document && $this->peopleService->getDocument($document, 'CNPJ')) {
+            throw new ConflictHttpException('Este CNPJ já está cadastrado.');
+        }
+
+        if ($email !== '' && $this->peopleService->getEmail($email)) {
+            throw new ConflictHttpException('Este e-mail já está cadastrado.');
+        }
+
+        if (
+            $phoneData['ddd'] !== '' &&
+            $phoneData['phone'] !== '' &&
+            $this->peopleService->getPhone(
+                (int) $phoneData['ddi'],
+                (int) $phoneData['ddd'],
+                $phoneData['phone']
+            )
+        ) {
+            throw new ConflictHttpException('Este telefone já está cadastrado.');
+        }
+    }
+
+    private function assertUsernameIsAvailable(string $username): void
+    {
+        $user = $this->manager->getRepository(User::class)->findOneBy([
+            'username' => $username,
+        ]);
+
+        if ($user instanceof User) {
+            throw new ConflictHttpException('Este usuário já está cadastrado.');
+        }
     }
 }

--- a/tests/Unit/Service/AccountRegistrationServiceTest.php
+++ b/tests/Unit/Service/AccountRegistrationServiceTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace ControleOnline\Tests\Unit\Service;
+
+use ControleOnline\Entity\Email;
+use ControleOnline\Service\AccountRegistrationService;
+use ControleOnline\Service\DomainService;
+use ControleOnline\Service\PeopleService;
+use ControleOnline\Service\UserService;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+
+class AccountRegistrationServiceTest extends TestCase
+{
+    public function testItRejectsAlreadyRegisteredEmailBeforePersisting(): void
+    {
+        $peopleService = $this->createMock(PeopleService::class);
+        $userService = $this->createMock(UserService::class);
+        $domainService = $this->createMock(DomainService::class);
+        $connection = $this->createMock(Connection::class);
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+
+        $entityManager
+            ->method('getConnection')
+            ->willReturn($connection);
+
+        $peopleService
+            ->method('getEmail')
+            ->with('maria@teste.com')
+            ->willReturn($this->createMock(Email::class));
+
+        $service = new AccountRegistrationService(
+            $userService,
+            $peopleService,
+            $domainService,
+            $entityManager
+        );
+
+        $this->expectException(ConflictHttpException::class);
+        $this->expectExceptionMessage('Este e-mail já está cadastrado.');
+
+        $service->registerFromPayload([
+            'people' => [
+                'name' => 'Maria',
+                'alias' => 'Maria',
+                'email' => 'maria@teste.com',
+                'document' => '12345678909',
+                'phone' => [
+                    'ddi' => '55',
+                    'ddd' => '11',
+                    'phone' => '999999999',
+                ],
+                'user' => [
+                    'user' => 'maria',
+                    'password' => '123456',
+                ],
+            ],
+        ]);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,15 @@
+<?php
+
+$autoloadPaths = [
+    __DIR__ . '/../vendor/autoload.php',
+    __DIR__ . '/../../../../vendor/autoload.php',
+];
+
+foreach ($autoloadPaths as $autoloadPath) {
+    if (is_file($autoloadPath)) {
+        require_once $autoloadPath;
+        return;
+    }
+}
+
+throw new RuntimeException('Composer autoload.php not found for people module tests.');


### PR DESCRIPTION
## Summary
- block public account registration when CPF, CNPJ, email, phone or username is already in use
- wrap `/create-account` registration in a transaction to avoid partial persistence when any step fails
- return conflict and validation errors with the proper HTTP status and add focused coverage for duplicate-email rejection

## Issue
- relates to https://github.com/ControleOnline/app-community/issues/65
- also covers the shared backend path used by https://github.com/ControleOnline/app-community/issues/64, because the PJ flow goes through the same `/create-account` transaction and duplicate checks for person and company identifiers

## Validation
- `git diff --check`
- automated PHP tests not run in this environment because the PHP runtime is unavailable in the workspace

## Notes
- `api-platform-people` exposes `dev`, but it is currently far from `master` and produced a non-isolated diff for this issue. This PR targets `master` to keep the review scoped.