### PR TITLE
[codex] Fix Scrutinizer bootstrap for phpcs

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -9,7 +9,11 @@ filter:
 build:
   nodes:
     analysis:
+      dependencies:
+        override:
+          - composer self-update --2
+          - composer install --no-interaction --prefer-dist --no-progress
       tests:
         override:
           - php-scrutinizer-run
-          - phpcs-run --standard=phpcs.xml src tests
+          - vendor/bin/phpcs --standard=phpcs.xml src tests

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,15 @@
+checks:
+  php: true
+
+filter:
+  excluded_paths:
+    - "vendor/*"
+    - "migrations/*"
+
+build:
+  nodes:
+    analysis:
+      tests:
+        override:
+          - php-scrutinizer-run
+          - phpcs-run --standard=phpcs.xml src tests

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -9,11 +9,9 @@ filter:
 build:
   nodes:
     analysis:
-      dependencies:
-        override:
-          - composer self-update --2
-          - composer install --no-interaction --prefer-dist --no-progress
-      tests:
-        override:
-          - php-scrutinizer-run
-          - vendor/bin/phpcs --standard=phpcs.xml src tests
+      commands:
+        - checkout-code ~/build
+        - cd ~/build && composer self-update --2
+        - cd ~/build && composer install --no-interaction --prefer-dist --no-progress
+        - cd ~/build && php-scrutinizer-run
+        - cd ~/build && vendor/bin/phpcs --standard=phpcs.xml src tests

--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,17 @@
             "ControleOnline\\Controller\\": "src/Controller/"
         }
     },
+    "require-dev": {
+        "squizlabs/php_codesniffer": "^3.10"
+    },
     "authors": [
         {
             "name": "Controle Online",
             "email": "luiz.kim@controleonline.com"
         }
     ],
-    "require": {}
+    "require": {},
+    "scripts": {
+        "lint": "phpcs --standard=phpcs.xml src tests"
+    }
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<ruleset name="ControleOnline People">
+    <description>Regras minimas para o Scrutinizer executar o PHP_CodeSniffer neste modulo.</description>
+
+    <arg name="basepath" value="."/>
+    <arg name="colors"/>
+    <arg name="extensions" value="php"/>
+    <arg name="parallel" value="4"/>
+
+    <file>src</file>
+    <file>tests</file>
+
+    <exclude-pattern>vendor/*</exclude-pattern>
+    <exclude-pattern>migrations/*</exclude-pattern>
+
+    <rule ref="PSR12"/>
+</ruleset>


### PR DESCRIPTION
## What changed
- add `squizlabs/php_codesniffer` as a dev dependency in `composer.json`
- add a module-level `phpcs.xml` targeting `src` and `tests`
- add `.scrutinizer.yml` with an explicit analysis pipeline for `php-scrutinizer-run` and `phpcs-run`

## Why
Scrutinizer was failing before the actual code checks because its `phpcs-run` bootstrap could not find a local CodeSniffer installation for this module. Declaring the tool locally and pointing Scrutinizer to an explicit ruleset gives the module a stable bootstrap path.

## Impact
- this module should stop failing at the "installing phpcs" stage
- linting becomes reproducible locally through `composer` and the `lint` script
- the same pattern can be reused in the next modules if this one turns green

## Validation
- validated the changed files structurally in the workspace
- could not run `php`, `composer`, or `phpcs` locally because this container does not have those binaries available and package installation is blocked by the environment network policy
- final confirmation depends on the remote Scrutinizer run for this PR
