### PR TITLE
fix: stop leaking user credentials through people reads

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -1,0 +1,28 @@
+name: Pull Request Checks
+
+on:
+  pull_request:
+  push:
+    branches:
+      - task-95
+
+jobs:
+  people-module:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+
+      - name: Validate composer files
+        run: composer validate --no-check-publish
+
+      - name: Install test dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -13,3 +13,16 @@ config\services.yaml
 imports:
     - { resource: "../modules/controleonline/orders/people/services/people.yaml" }    
 ```
+
+## Nested user serialization
+
+Broad `People` reads must not expose nested `User` credentials or identifiers.
+
+Current behavior:
+- broad `people:read` responses no longer serialize nested `User` credentials from the related person record
+- public or broad `People` reads must not be used as a side channel for `username`, `apiKey`, or other sensitive `User` fields
+- sensitive user management stays on the dedicated `users` resource and its guarded service path
+
+Validation:
+- focused coverage lives in `tests/Unit/Entity/PeopleSerializationGroupsTest.php`
+- the branch workflow `Pull Request Checks` is the canonical automated evidence for this serialization rule in review branches

--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,19 @@
             "ControleOnline\\Controller\\": "src/Controller/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "ControleOnline\\Tests\\": "tests/"
+        }
+    },
     "authors": [
         {
             "name": "Controle Online",
             "email": "luiz.kim@controleonline.com"
         }
     ],
-    "require": {}
+    "require": {},
+    "require-dev": {
+        "phpunit/phpunit": "^12.1"
+    }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.1/phpunit.xsd"
+    bootstrap="tests/bootstrap.php"
+    colors="true"
+    cacheDirectory=".phpunit.cache"
+>
+    <testsuites>
+        <testsuite name="People Module Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Entity/People.php
+++ b/src/Entity/People.php
@@ -363,7 +363,6 @@ class People
         'category:read',
         'document:read',
         'email:read',
-        'people:read',
         'people:write',
         'order_detail_status:read',
         'task_interaction:read',

--- a/tests/Unit/Entity/PeopleSerializationGroupsTest.php
+++ b/tests/Unit/Entity/PeopleSerializationGroupsTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace ControleOnline\Tests\Unit\Entity;
+
+use PHPUnit\Framework\TestCase;
+
+class PeopleSerializationGroupsTest extends TestCase
+{
+    public function testPeopleBroadReadNoLongerExposesNestedUsers(): void
+    {
+        $source = file_get_contents(__DIR__ . '/../../../src/Entity/People.php');
+
+        self::assertIsString($source);
+        self::assertMatchesRegularExpression('/private \$user;/', $source);
+        self::assertMatchesRegularExpression('/#\[Groups\(\[(?:(?!people:read).)*people:write(?:(?!people:read).)*\]\)\]\s*private \$user;/s', $source);
+        self::assertDoesNotMatchRegularExpression('/#\[Groups\(\[(?:(?!\]\)\]).)*people:read(?:(?!\]\)\]).)*\]\)\]\s*private \$user;/s', $source);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,15 @@
+<?php
+
+$autoloadPaths = [
+    __DIR__ . '/../vendor/autoload.php',
+    __DIR__ . '/../../../../vendor/autoload.php',
+];
+
+foreach ($autoloadPaths as $autoloadPath) {
+    if (is_file($autoloadPath)) {
+        require_once $autoloadPath;
+        return;
+    }
+}
+
+throw new RuntimeException('Composer autoload.php not found for people module tests.');


### PR DESCRIPTION
Refs ControleOnline/app-community#95

## Summary
- remove the broad `people:read` exposure of nested `user` data from `People`
- add focused PHPUnit coverage so the branch proves `People` no longer serializes nested users on broad reads
- complement the existing `api-platform-users#5` branch by removing the residual `people:read` groups from `User` identifiers and secrets

## Validation
- `api-platform-people`: `Pull Request Checks` succeeded on head `02c3ef78dc5fbae3b310163051857f3fe4c2c5a9` (run `#12`)
- `api-platform-users`: `Pull Request Checks` succeeded on head `121f470d8b06cd8dea29b1aaa9c8c17632387785` (run `#41`)
- local PHP execution was not possible in this environment, so executable evidence for this round is published through the branch workflows

## Notes
- this branch starts from `master` as required by the execution flow and targets `master` to keep the diff isolated from unrelated drift
- the functional security trail for this issue now spans `ControleOnline/api-platform-people#6` and `ControleOnline/api-platform-users#5`