### PR TITLE
feat: allow multiple file attachments per person document

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@
 - Se `People` mantiver relacao com `User`, essa relacao so pode aparecer em grupo e operacao com autorizacao tao forte quanto a leitura direta de `User`.
 - Operacoes amplas ou publicas de `People`, incluindo `Get` com `PUBLIC_ACCESS`, nunca podem se tornar caminho lateral para leitura de credenciais ou segredos de `User`.
 - Listagens de `People` consumidas por `DefaultTable` React precisam de `CustomOrFilter`, `OrderFilter` e `DateFilter` alinhados com os campos declarados no store, com datas ordenando pelo valor persistido.
+- Documentos de pessoa continuam sendo a entidade canonica para `tipo + numero`; anexos agora pertencem a `DocumentFile` para permitir multiplos arquivos por documento sem quebrar o campo legado `file`.
 
 ## Regras de vendedores e comissao
 - O vinculo `sellers-client` em `people_link` e sensivel porque revela e altera a relacao comercial entre cliente e vendedor.

--- a/src/Entity/Document.php
+++ b/src/Entity/Document.php
@@ -14,6 +14,8 @@ use ApiPlatform\Metadata\Put;
 use ApiPlatform\Metadata\Delete;
 
 use ControleOnline\Repository\DocumentRepository;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ApiResource(
@@ -66,6 +68,15 @@ class Document
     #[ORM\ManyToOne(targetEntity: DocumentType::class)]
     #[Groups(['people:read', 'document:read', 'carrier:read', 'document:write'])]
     private DocumentType $documentType;
+
+    #[ORM\OneToMany(targetEntity: DocumentFile::class, mappedBy: 'document', orphanRemoval: true)]
+    #[Groups(['people:read', 'document:read'])]
+    private Collection $documentFiles;
+
+    public function __construct()
+    {
+        $this->documentFiles = new ArrayCollection();
+    }
 
     public function getId(): int
     {
@@ -121,5 +132,26 @@ class Document
     public function getDocumentType(): DocumentType
     {
         return $this->documentType;
+    }
+
+    public function getDocumentFiles(): Collection
+    {
+        return $this->documentFiles;
+    }
+
+    public function addDocumentFile(DocumentFile $documentFile): self
+    {
+        if (!$this->documentFiles->contains($documentFile)) {
+            $this->documentFiles[] = $documentFile;
+            $documentFile->setDocument($this);
+        }
+
+        return $this;
+    }
+
+    public function removeDocumentFile(DocumentFile $documentFile): self
+    {
+        $this->documentFiles->removeElement($documentFile);
+        return $this;
     }
 }

--- a/src/Entity/DocumentFile.php
+++ b/src/Entity/DocumentFile.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace ControleOnline\Entity;
+
+use Symfony\Component\Serializer\Attribute\Groups;
+
+use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
+use ApiPlatform\Metadata\ApiFilter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\Put;
+
+use ControleOnline\Repository\DocumentFileRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ApiResource(
+    operations: [
+        new Get(security: "is_granted('ROLE_HUMAN')"),
+        new Put(
+            security: "is_granted('ROLE_HUMAN')",
+            denormalizationContext: ['groups' => ['document_file:write']]
+        ),
+        new Delete(security: "is_granted('ROLE_HUMAN')"),
+        new Post(securityPostDenormalize: "is_granted('ROLE_HUMAN')"),
+        new GetCollection(security: "is_granted('ROLE_HUMAN')")
+    ],
+    formats: ['jsonld', 'json', 'html', 'jsonhal', 'csv' => ['text/csv']],
+    normalizationContext: ['groups' => ['document_file:read']],
+    denormalizationContext: ['groups' => ['document_file:write']]
+)]
+#[ApiFilter(filterClass: SearchFilter::class, properties: ['document' => 'exact', 'file' => 'exact', 'file.fileType' => 'exact'])]
+#[ORM\Table(name: 'document_file')]
+#[ORM\Index(name: 'document_id', columns: ['document_id'])]
+#[ORM\Index(name: 'file_id', columns: ['file_id'])]
+#[ORM\UniqueConstraint(name: 'document_file_unique', columns: ['document_id', 'file_id'])]
+#[ORM\Entity(repositoryClass: DocumentFileRepository::class)]
+class DocumentFile
+{
+    #[ORM\Column(name: 'id', type: 'integer', nullable: false)]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    #[Groups(['document:read', 'document_file:read', 'people:read'])]
+    private int $id = 0;
+
+    #[ORM\JoinColumn(name: 'document_id', referencedColumnName: 'id', nullable: false)]
+    #[ORM\ManyToOne(targetEntity: Document::class, inversedBy: 'documentFiles')]
+    #[Groups(['document_file:read', 'document_file:write'])]
+    private Document $document;
+
+    #[ORM\JoinColumn(name: 'file_id', referencedColumnName: 'id', nullable: false)]
+    #[ORM\ManyToOne(targetEntity: File::class)]
+    #[Groups(['document:read', 'document_file:read', 'document_file:write', 'people:read'])]
+    private File $file;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getDocument(): Document
+    {
+        return $this->document;
+    }
+
+    public function setDocument(Document $document): self
+    {
+        $this->document = $document;
+        return $this;
+    }
+
+    public function getFile(): File
+    {
+        return $this->file;
+    }
+
+    public function setFile(File $file): self
+    {
+        $this->file = $file;
+        return $this;
+    }
+}

--- a/src/Repository/DocumentFileRepository.php
+++ b/src/Repository/DocumentFileRepository.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace ControleOnline\Repository;
+
+use ControleOnline\Entity\DocumentFile;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+class DocumentFileRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, DocumentFile::class);
+    }
+}


### PR DESCRIPTION
## Summary
- add a new `DocumentFile` resource so one person document can own multiple uploaded files
- preserve the legacy singular `file` relation on `Document` for backward compatibility while exposing `documentFiles` for the new flow
- document the ownership split between `Document` (`type + number`) and `DocumentFile` (attachments)

## Validation
- reviewed the entity and repository changes published on `task-139`
- did not run automated tests in this environment because this session has no local checkout or executable backend workspace for this repository

Refs ControleOnline/app-community#139